### PR TITLE
test: import apptests dependency

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,5 @@
+module github.com/nutanix-cloud-native/nkp-partner-catalog/tests
+
+go 1.24.1
+
+require github.com/mesosphere/kommander-applications/apptests v0.0.0-20250414162601-a8198de6ab38

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,0 +1,2 @@
+github.com/mesosphere/kommander-applications/apptests v0.0.0-20250414162601-a8198de6ab38 h1:exDmmKw8f9mGPGjo6+shsR6nwqxFXlVJQAPQwT2GI6k=
+github.com/mesosphere/kommander-applications/apptests v0.0.0-20250414162601-a8198de6ab38/go.mod h1:gIHKwrU9IrXpT+SaYl48n92b6mIZhYOPTdYpavaGU9E=

--- a/tests/main.go
+++ b/tests/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/mesosphere/kommander-applications/apptests/constants"
+)
+
+func main() {
+	fmt.Println(constants.Traefik)
+}


### PR DESCRIPTION
In near future, we shall:

- Split the `apptests` module into two - one that acts as a library and one that is specific to k-apps.
- Make `apptests` into its own github repo so that it can follow its one release cycle and allow us to add more features that gets shared across all the catalog repos.

For now, we shall:

- Have this direct dependency so that we can write tests here.