### PR TITLE
fix: update to OCI Artifacts push

### DIFF
--- a/.github/workflows/publish-oci-artifacts.yaml
+++ b/.github/workflows/publish-oci-artifacts.yaml
@@ -9,7 +9,7 @@ on:
         type: string
       ARTIFACT_APPS:
         description: "Apps to bundle (name=version). Can be a comma-separated list."
-        required: true
+        required: false
         type: string
 
 jobs:

--- a/just/release.just
+++ b/just/release.just
@@ -5,5 +5,10 @@ set unstable
 [script]
 publish-artifacts registry collection-tag apps: nkp-cli
   tmpdir="$(mktemp -d)"
-  "{{ NKP_CLI }}" create catalog-bundle --repo-dir "{{ REPO_ROOT }}" --collection-tag "{{collection-tag}}" --apps="{{apps}}" --output-file "$tmpdir/bundle.tar"
+  if [ -n "{{apps}}" ]; then
+    apps_flag="--apps={{apps}}"
+  else
+    apps_flag=""
+  fi
+  "{{ NKP_CLI }}" create catalog-bundle --repo-dir "{{ REPO_ROOT }}" --collection-tag "{{collection-tag}}" ${apps_flag} --output-file "$tmpdir/bundle.tar"
   "{{ NKP_CLI }}" push bundle --bundle "$tmpdir/bundle.tar" --to-registry "{{ registry }}"


### PR DESCRIPTION
<!--
 Copyright 2025 Nutanix. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->

**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->
https://jira.nutanix.com/browse/NCN-108720

Need to update the OCI Artifact for nkp-partner-catalog after https://github.com/nutanix-cloud-native/nkp-partner-catalog/pull/30 merged

Tested locally
```
zihui.liu@K0X95YV6M2 nkp-partner-catalog % /Users/zihui.liu/Desktop/nkp-catalog-cli create catalog-bundle --repo-dir ../nkp-partner-catalog --collection-tag 2.16                              
Bundling 0 application(s) (airgapped : false)
 ✓ Building OCI artifact nkp-partner-catalog/collection:2.16 
 ✓ Pulling requested images [====================================>1/1] (time elapsed 00s) 
 ✓ Saving application bundle to /Users/zihui.liu/Desktop/nkp-partner-catalog/nkp-partner-catalog.tar

Run the following to push the artifact to your registry:

	nkp push bundle --bundle /Users/zihui.liu/Desktop/nkp-partner-catalog/nkp-partner-catalog.tar --to-registry <your-registry-url>


Run the following command to create catalog artifact(s) after pushing them:

	nkp create catalog-collection --url oci://<registry-url>/nkp-partner-catalog/collection --tag 2.16 --workspace kommander-workspace
```