### PR TITLE
docs: refresh root and applications README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to nkp-partner-catalog
+# Contributing to the NKP Partner Catalog
 
-Follow these guidelines to add or update partner applications.
+Follow these guidelines to add or update partner applications in the **Nutanix Kubernetes Platform (NKP) Partner Catalog** repository.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ New applications and updates are contributed via pull request and are reviewed a
 
 **Quick start for contributors:** clone the repo, use the workflow in [CONTRIBUTING.md](CONTRIBUTING.md) (`nkp generate`, validate with `nkp validate catalog-repository`, open a PR with signed commits).
 
+## Partner Catalog in NKP (Nutanix documentation)
+
+End-user and operator documentation for the **NKP Partner Catalog** in a cluster (for example UI workflows and platform behavior) lives in the [Nutanix Support & Insights](https://portal.nutanix.com) portal, under the **Nutanix Kubernetes Platform** documentation **for your NKP release**. Topic titles and deep links include the product version, so always use the doc set that matches the NKP version you run. From the portal, open your release’s NKP guide and go to the **Partner Catalog** section, or search for `Partner Catalog`.
+
+**Example deep link (NKP 2.17):** [Partner Catalog in NKP](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Kubernetes-Platform-v2_17:top-partner-catalog-in-nkp-c.html)
+
 ## Signed commits
 
 All commits to this repository **must be signed**. See GitHub’s guide: [Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification).

--- a/README.md
+++ b/README.md
@@ -2,25 +2,34 @@ All source code and other contents in this repository are covered by the Nutanix
 
 # Nutanix NKP Partner Catalog
 
-This repository is dedicated to storing applications manifests and other metadata required for partner applications. Contributions for new applications should be made here and will be reviewed and merged upon approval by the internal team.
+The **Nutanix Kubernetes Platform (NKP) Partner Catalog** is the source of truth for partner application manifests and metadata used to list, deploy, and upgrade applications in NKP. This repository holds Flux- and Helm-based definitions that partners maintain so that their customers can install and upgrade catalog apps through NKP in a consistent way.
 
----
+New applications and updates are contributed via pull request and are reviewed and merged after approval by the Nutanix team. OCI artifacts for published applications are built and pushed post-merge; see [CONTRIBUTING.md](CONTRIBUTING.md) for registry layout and manifest details.
 
-## Finding your way around
+## Who this repository is for
 
-- **`applications/`**
-  Contains all partner applications. Each application can have multiple versions organized in **semver-named subdirectories**. Each version directory includes the manifest files corresponding that single version.
+| Audience | Use |
+| -------- | --- |
+| **Partners and ISVs** | Publish and maintain application versions, metadata, and tests so apps appear in the catalog and behave correctly on install and upgrade. |
+| **NKP users and operators** | Consume catalog content indirectly through NKP; this repo is the upstream source for what ships in the partner catalog experience. |
 
-- **`just/`**
-  Contains [just](https://just.systems/man/en/introduction.html) recipes used to perform various actions on the applications.
+## Repository layout
 
-- **`apptests/`**
-  Contains test suites for each application's installation and upgrade scenarios.
+| Path | Description |
+| ---- | ----------- |
+| **`applications/`** | Partner applications. Each app can have multiple versions in **semver-named** subdirectories; each version directory contains the manifests for that release. See [`applications/README.md`](applications/README.md). |
+| **`just/`** | [just](https://just.systems/man/en/introduction.html) recipes for common tasks against the applications in this repo. |
+| **`apptests/`** | Automated test suites for installation and upgrade scenarios per application. |
 
----
+## Documentation
 
-## Signing commits
+| Document | Purpose |
+| -------- | ------- |
+| [**Contributing**](CONTRIBUTING.md) | Prerequisites (including devbox), generating app scaffolding with `nkp`, manifest structure, validation, and `apptests` requirements. |
+| [**Applications**](applications/README.md) | Overview of the `applications/` directory and version layout. |
 
-All commits to this repository **must be signed**.
-Learn how to sign your commits here:
-[Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+**Quick start for contributors:** clone the repo, use the workflow in [CONTRIBUTING.md](CONTRIBUTING.md) (`nkp generate`, validate with `nkp validate catalog-repository`, open a PR with signed commits).
+
+## Signed commits
+
+All commits to this repository **must be signed**. See GitHub’s guide: [Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 All source code and other contents in this repository are covered by the Nutanix License and Services Agreement, which is located at https://www.nutanix.com/legal/eula
 
-# Nutanix NKP Partner Catalog
+# NKP Partner Catalog
 
-The **Nutanix Kubernetes Platform (NKP) Partner Catalog** is the source of truth for partner application manifests and metadata used to list, deploy, and upgrade applications in NKP. This repository holds Flux- and Helm-based definitions that partners maintain so that their customers can install and upgrade catalog apps through NKP in a consistent way.
+The **Nutanix Kubernetes Platform (NKP) Partner Catalog** is the source of truth for partner application manifests and metadata used to list, deploy, and upgrade applications in NKP. This repository holds Flux- and Helm-based definitions that partners maintain so that their customers can install and upgrade catalog apps through the **NKP Partner Catalog** in a consistent way.
 
 New applications and updates are contributed via pull request and are reviewed and merged after approval by the Nutanix team. OCI artifacts for published applications are built and pushed post-merge; see [CONTRIBUTING.md](CONTRIBUTING.md) for registry layout and manifest details.
 
@@ -10,8 +10,8 @@ New applications and updates are contributed via pull request and are reviewed a
 
 | Audience | Use |
 | -------- | --- |
-| **Partners and ISVs** | Publish and maintain application versions, metadata, and tests so apps appear in the catalog and behave correctly on install and upgrade. |
-| **NKP users and operators** | Consume catalog content indirectly through NKP; this repo is the upstream source for what ships in the partner catalog experience. |
+| **Partners and ISVs** | Publish and maintain application versions, metadata, and tests so apps appear in the **NKP Partner Catalog** and behave correctly on install and upgrade. |
+| **NKP users and operators** | Consume catalog content indirectly through NKP; this repo is the upstream source for what ships in the **NKP Partner Catalog** experience. |
 
 ## Repository layout
 
@@ -26,7 +26,7 @@ New applications and updates are contributed via pull request and are reviewed a
 | Document | Purpose |
 | -------- | ------- |
 | [**Contributing**](CONTRIBUTING.md) | Prerequisites (including devbox), generating app scaffolding with `nkp`, manifest structure, validation, and `apptests` requirements. |
-| [**Applications**](applications/README.md) | Overview of the `applications/` directory and version layout. |
+| [**NKP Partner Catalog applications**](applications/README.md) | Overview of the `applications/` directory and version layout. |
 
 **Quick start for contributors:** clone the repo, use the workflow in [CONTRIBUTING.md](CONTRIBUTING.md) (`nkp generate`, validate with `nkp validate catalog-repository`, open a PR with signed commits).
 

--- a/applications/README.md
+++ b/applications/README.md
@@ -1,3 +1,18 @@
-# Nutanix NKP Partner Catalog Applications
+# Partner catalog applications
 
-This directory contains all partner applications. Each application can have multiple versions organized in **semver-named subdirectories**. Each version directory includes the manifest files corresponding that single version. Contributions for new applications should be made here and will be reviewed and merged upon approval by the internal team.
+This directory contains **partner applications** for the Nutanix Kubernetes Platform (NKP) partner catalog. Each subdirectory is one application; under it, **semver-named** version directories (for example `1.2.0`) hold the manifests and metadata for that release.
+
+## Directory layout
+
+| Level | Description |
+| ----- | ----------- |
+| **`<application-name>/`** | One folder per catalog application. |
+| **`<application-name>/<semver>/`** | One folder per released version. It includes Flux and Helm wiring (for example HelmRelease and Kustomization files) and **`metadata.yaml`**, which the NKP UI uses to display application details. |
+
+Generated layouts and field-level guidance are described in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## How to contribute
+
+Additions and updates go through pull request and are reviewed and merged after approval by the Nutanix team. Use the steps in [CONTRIBUTING.md](../CONTRIBUTING.md) (`nkp generate`, validation, and `apptests` where required).
+
+For repository-wide context (OCI publishing, signing policy, and other top-level paths), see the [root README](../README.md).

--- a/applications/README.md
+++ b/applications/README.md
@@ -1,12 +1,12 @@
-# Partner catalog applications
+# NKP Partner Catalog applications
 
-This directory contains **partner applications** for the Nutanix Kubernetes Platform (NKP) partner catalog. Each subdirectory is one application; under it, **semver-named** version directories (for example `1.2.0`) hold the manifests and metadata for that release.
+This directory contains **partner applications** for the **Nutanix Kubernetes Platform (NKP) Partner Catalog**. Each subdirectory is one application; under it, **semver-named** version directories (for example `1.2.0`) hold the manifests and metadata for that release.
 
 ## Directory layout
 
 | Level | Description |
 | ----- | ----------- |
-| **`<application-name>/`** | One folder per catalog application. |
+| **`<application-name>/`** | One folder per **NKP Partner Catalog** application. |
 | **`<application-name>/<semver>/`** | One folder per released version. It includes Flux and Helm wiring (for example HelmRelease and Kustomization files) and **`metadata.yaml`**, which the NKP UI uses to display application details. |
 
 Generated layouts and field-level guidance are described in [CONTRIBUTING.md](../CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

- **Root `README.md`:** Structured overview for the NKP partner catalog (audience, layout table, documentation links, OCI post-merge pointer, signed commits).
- **`applications/README.md`:** Matches that tone with a clear per-app and per-version layout table, `metadata.yaml` callout, and links to `CONTRIBUTING.md` and the root README.

## Motivation

Make the public-facing docs easier to scan for partners and operators without dropping existing requirements (review process, semver layout, signing).

Made with [Cursor](https://cursor.com)