### PR TITLE
chore: add kasm application version to release artifacts

### DIFF
--- a/.release/stable.yaml
+++ b/.release/stable.yaml
@@ -7,6 +7,8 @@ releases:
     applications:
       - name: cloudcasa-agent
         version: "3.4.6"
+      - name: kasm
+        version: 1.1181.0
       - name: traefik-hub
         version: "3.17.11"
       - name: traefik-hub
@@ -18,6 +20,8 @@ releases:
     applications:
       - name: cloudcasa-agent
         version: "3.4.6"
+      - name: kasm
+        version: 1.1181.0
       - name: traefik-hub
         version: "3.17.11"
       - name: traefik-hub
@@ -29,6 +33,8 @@ releases:
     applications:
       - name: cloudcasa-agent
         version: "3.4.6"
+      - name: kasm
+        version: 1.1181.0
       - name: traefik-hub
         version: "3.17.11"
       - name: traefik-hub


### PR DESCRIPTION
Added 'kasm' application with version '1.1181.0' to the stable.yaml file so that it is pushed to 2.16, 2.17 and 2.18 NKP Clusters

<!--
 Copyright 2025 Nutanix. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->

**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->
Fixes #41 
