### PR TITLE
fix: detach `docs` from root project devbox and justfile

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -3,7 +3,7 @@
 #
 # Build docs from main (docs/source + docs/site) and deploy via GitHub Pages artifacts.
 
-name: deploy-docs
+name: Deploy Docs
 
 on:
   push:
@@ -36,11 +36,12 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.15.0
         with:
+          project-path: docs
           enable-cache: true
           skip-nix-installation: true
 
       - name: Build docs
-        run: devbox run -- just docs-build
+        run: cd docs && devbox run -- just docs-build
 
       - name: Upload static files as Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,6 @@ This directory contains docs source and docs tooling.
   - `source/cli/` (generated CLI reference source files)
   - `source/schemas/v1/` (generated schema JSON files used by API docs pages)
 - `site/` — Docusaurus app and config
-- `docs.just` — docs recipes used by the repo `justfile`
-- `devbox.json` — docs-local devbox commands
 
 ## Local commands
 

--- a/docs/justfile
+++ b/docs/justfile
@@ -1,21 +1,22 @@
+set unstable
 # Docs recipes for nkp-partner-catalog.
 # docs/source and docs/site live on main; built output is published to gh-pages.
 
 [script]
 docs-build base_url='/nkp-partner-catalog/':
     ROOT="{{ justfile_directory() }}"
-    mkdir -p "$ROOT/docs/site/static/schemas/v1"
-    rsync -a --delete "$ROOT/docs/source/schemas/v1/" "$ROOT/docs/site/static/schemas/v1/"
-    cd "$ROOT/docs/site"
+    mkdir -p "$ROOT/site/static/schemas/v1"
+    rsync -a --delete "$ROOT/source/schemas/v1/" "$ROOT/site/static/schemas/v1/"
+    cd "$ROOT/site"
     npm ci --prefer-offline
     BASE_URL="{{ base_url }}" npm run build
 
 [script]
 docs-local host='0.0.0.0' port='3000' base_url='/':
     ROOT="{{ justfile_directory() }}"
-    mkdir -p "$ROOT/docs/site/static/schemas/v1"
-    rsync -a --delete "$ROOT/docs/source/schemas/v1/" "$ROOT/docs/site/static/schemas/v1/"
-    cd "$ROOT/docs/site"
+    mkdir -p "$ROOT/site/static/schemas/v1"
+    rsync -a --delete "$ROOT/source/schemas/v1/" "$ROOT/site/static/schemas/v1/"
+    cd "$ROOT/site"
     npm ci --prefer-offline
     BASE_URL="{{ base_url }}" npm run build
     BASE_URL="{{ base_url }}" npm run docusaurus -- serve --dir build --host "{{ host }}" --port "{{ port }}"
@@ -31,7 +32,7 @@ docs-deploy branch='gh-pages' repo='git@github.com:nutanix-cloud-native/nkp-part
         git clone --branch {{ branch }} --single-branch --depth 1 {{ repo }} "$DEPLOY_DIR"
     fi
 
-    rsync -a --delete --exclude='.git' "$ROOT/docs/site/build/" "$DEPLOY_DIR/"
+    rsync -a --delete --exclude='.git' "$ROOT/site/build/" "$DEPLOY_DIR/"
     cd "$DEPLOY_DIR"
     git add -A
     echo ""

--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@ import 'just/tools.just'
 import 'just/validate.just'
 import 'just/release.just'
 import 'just/test.just'
-import 'docs/docs.just'
 
 # Runs pre-commit hooks and gitlint
 pre-commit:


### PR DESCRIPTION
<!--
 Copyright 2025 Nutanix. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->

**Which issue(s) does this PR fix?**:
<!--
In addition, please:
- Describe the tests that you ran to verify your changes.
- Provide output from the tests and any manual steps needed to replicate the tests.
- Add any other special notes for reviewers.
-->

No reason to share the project devbox and justfile for docs site tooling. Keeping it isolated for easier tooling.
