### PR TITLE
ci: harden docs npm install workflow execution

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -13,11 +13,6 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: deploy-docs
   cancel-in-progress: false
@@ -26,6 +21,8 @@ jobs:
   build:
     runs-on:
       - self-hosted-ncn-docker-medium
+    permissions:
+      contents: read
     steps:
       - name: Check out main
         uses: actions/checkout@v4
@@ -52,6 +49,9 @@ jobs:
     needs: build
     runs-on:
       - self-hosted-ncn-docker-medium
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/justfile
+++ b/docs/justfile
@@ -8,7 +8,7 @@ docs-build base_url='/nkp-partner-catalog/':
     mkdir -p "$ROOT/site/static/schemas/v1"
     rsync -a --delete "$ROOT/source/schemas/v1/" "$ROOT/site/static/schemas/v1/"
     cd "$ROOT/site"
-    npm ci --prefer-offline
+    npm ci --prefer-offline --ignore-scripts
     BASE_URL="{{ base_url }}" npm run build
 
 [script]
@@ -17,7 +17,7 @@ docs-local host='0.0.0.0' port='3000' base_url='/':
     mkdir -p "$ROOT/site/static/schemas/v1"
     rsync -a --delete "$ROOT/source/schemas/v1/" "$ROOT/site/static/schemas/v1/"
     cd "$ROOT/site"
-    npm ci --prefer-offline
+    npm ci --prefer-offline --ignore-scripts
     BASE_URL="{{ base_url }}" npm run build
     BASE_URL="{{ base_url }}" npm run docusaurus -- serve --dir build --host "{{ host }}" --port "{{ port }}"
 

--- a/docs/site/devbox.json
+++ b/docs/site/devbox.json
@@ -4,7 +4,7 @@
   "shell": {
     "init_hook": ["echo 'Welcome to devbox!' > /dev/null"],
     "scripts": {
-      "install": ["npm install"],
+      "install": ["npm install --ignore-scripts"],
       "start": ["npm run start"],
       "build": ["npm run build"],
       "serve": ["npm run serve"]


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
(ci: harden docs npm install workflow execution)

https://jira.nutanix.com/browse/NCN-114490

Updated docs/justfile to run installs with lifecycle scripts disabled:
docs-build: npm ci --prefer-offline --ignore-scripts
docs-local: npm ci --prefer-offline --ignore-scripts
Updated docs/site/devbox.json install script from npm install to npm install --ignore-scripts.
Updated .github/workflows/deploy-docs.yaml to remove workflow-level token permissions and scope permissions per job:
build job: contents: read only
deploy job: pages: write, id-token: write