### PR TITLE
feat: align Traefik Hub AI catalog metadata for NKP 2.19

### DIFF
--- a/applications/traefik-hub/3.17.11/metadata.yaml
+++ b/applications/traefik-hub/3.17.11/metadata.yaml
@@ -5,7 +5,6 @@ category:
 appScreens:
 - ai
 - general
-nkpVersionSupport: 2.19.0
 displayName: Traefik API Management
 description: Cloud-Native API Intelligence & Management Platform with GitOps-Native Governance
 licensing:

--- a/applications/traefik-hub/3.17.11/metadata.yaml
+++ b/applications/traefik-hub/3.17.11/metadata.yaml
@@ -1,7 +1,11 @@
 schema: catalog.nkp.nutanix.com/v1/application-metadata
 allowMultipleInstances: false
 category:
-- api-gateway
+- inferencing-serving
+appScreens:
+- ai
+- general
+nkpVersionSupport: 2.19.0
 displayName: Traefik API Management
 description: Cloud-Native API Intelligence & Management Platform with GitOps-Native Governance
 licensing:

--- a/applications/traefik-hub/3.18.1/metadata.yaml
+++ b/applications/traefik-hub/3.18.1/metadata.yaml
@@ -5,7 +5,6 @@ category:
 appScreens:
   - ai
   - general
-nkpVersionSupport: 2.19.0
 displayName: Traefik API Management
 description: Cloud-Native API Intelligence & Management Platform with GitOps-Native Governance
 licensing:

--- a/applications/traefik-hub/3.18.1/metadata.yaml
+++ b/applications/traefik-hub/3.18.1/metadata.yaml
@@ -1,7 +1,11 @@
 schema: catalog.nkp.nutanix.com/v1/application-metadata
 allowMultipleInstances: false
 category:
-  - api-gateway
+  - inferencing-serving
+appScreens:
+  - ai
+  - general
+nkpVersionSupport: 2.19.0
 displayName: Traefik API Management
 description: Cloud-Native API Intelligence & Management Platform with GitOps-Native Governance
 licensing:


### PR DESCRIPTION
Ticket:
https://jira.nutanix.com/secure/RapidBoard.jspa?rapidView=3430&view=detail&selectedIssue=NCN-115773#


## Summary
- Update Traefik Hub metadata for versions `3.17.11` and `3.18.1` to use AI subcategory-only classification (`inferencing-serving`)
- Add explicit `appScreens` values (`ai`, `general`) for dual catalog visibility while preserving a single category value
- Set `nkpVersionSupport` to `2.19.0` for both Traefik Hub metadata entries

## Test plan
- [x] `pre-commit run --files applications/traefik-hub/3.17.11/metadata.yaml applications/traefik-hub/3.18.1/metadata.yaml`
- [x] `git diff main...HEAD`


## Design doc:
https://docs.google.com/document/d/1NcHD4iEKczp2GX-gYNmRTSEkqnrVzW1QBnREISoFkek/edit?tab=t.0#heading=h.pnpnvh1kelv