### PR TITLE
fix(e2e tests): running in existing kube cluster is possible again

### DIFF
--- a/apptests/suites/cloudcasaagent_test.go
+++ b/apptests/suites/cloudcasaagent_test.go
@@ -26,8 +26,10 @@ var _ = Describe("cloudcasa-agent Tests", Label("cloudcasa-agent"), func() {
 			err := SetupKindCluster()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = env.InstallLatestFlux(ctx)
-			Expect(err).ToNot(HaveOccurred())
+			if !useExistingCluster {
+				err = env.InstallLatestFlux(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			}
 		})
 
 		AfterAll(func() {

--- a/apptests/suites/kasm_test.go
+++ b/apptests/suites/kasm_test.go
@@ -18,6 +18,7 @@ import (
 	apimeta "github.com/fluxcd/pkg/apis/meta"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -94,8 +95,10 @@ var _ = Describe("kasm Tests", Label("kasm"), func() {
 			err := SetupKindCluster()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = env.InstallLatestFlux(ctx)
-			Expect(err).ToNot(HaveOccurred())
+			if !useExistingCluster {
+				err = env.InstallLatestFlux(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			}
 		})
 
 		AfterAll(func() {
@@ -110,6 +113,10 @@ var _ = Describe("kasm Tests", Label("kasm"), func() {
 		It("should install successfully with default config", func() {
 			tlsSecret := createSelfSignedTLSSecret("kasm-tls-secret", catalog.DefaultNamespace)
 			err := k8sClient.Create(ctx, tlsSecret)
+			if apierrors.IsAlreadyExists(err) {
+				_ = k8sClient.Delete(ctx, tlsSecret)
+				err = k8sClient.Create(ctx, tlsSecret)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			k = catalog.NewAppScenario("kasm", *appVersion).(*catalog.App)
@@ -169,8 +176,10 @@ var _ = Describe("kasm Tests", Label("kasm"), func() {
 			err := SetupKindCluster()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = env.InstallLatestFlux(ctx)
-			Expect(err).ToNot(HaveOccurred())
+			if !useExistingCluster {
+				err = env.InstallLatestFlux(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			}
 		})
 
 		AfterAll(func() {
@@ -185,7 +194,12 @@ var _ = Describe("kasm Tests", Label("kasm"), func() {
 		It("should install the previous version successfully", func() {
 			tlsSecret := createSelfSignedTLSSecret("kasm-tls-secret", catalog.DefaultNamespace)
 			err := k8sClient.Create(ctx, tlsSecret)
+			if apierrors.IsAlreadyExists(err) {
+				_ = k8sClient.Delete(ctx, tlsSecret)
+				err = k8sClient.Create(ctx, tlsSecret)
+			}
 			Expect(err).ToNot(HaveOccurred())
+
 			err = k.InstallPreviousVersion(ctx, env)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/apptests/suites/suites_test.go
+++ b/apptests/suites/suites_test.go
@@ -50,6 +50,7 @@ var _ = BeforeSuite(func() {
 
 		k8sClient, err = genericClient.New(typedClient.Config(), genericClient.Options{Scheme: scheme})
 		Expect(err).ShouldNot(HaveOccurred())
+		env.SetClient(k8sClient)
 	} else {
 		var err error
 		network, err = kind.EnsureDockerNetworkExist(ctx, "", false)

--- a/apptests/suites/traefikhub_test.go
+++ b/apptests/suites/traefikhub_test.go
@@ -77,8 +77,10 @@ var _ = Describe("traefik-hub Tests", Label("traefik-hub"), func() {
 			err := SetupKindCluster()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = env.InstallLatestFlux(ctx)
-			Expect(err).ToNot(HaveOccurred())
+			if !useExistingCluster {
+				err = env.InstallLatestFlux(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			}
 		})
 
 		AfterAll(func() {
@@ -156,8 +158,10 @@ var _ = Describe("traefik-hub Tests", Label("traefik-hub"), func() {
 			err := SetupKindCluster()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = env.InstallLatestFlux(ctx)
-			Expect(err).ToNot(HaveOccurred())
+			if !useExistingCluster {
+				err = env.InstallLatestFlux(ctx)
+				Expect(err).ToNot(HaveOccurred())
+			}
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
Without this running the tests in an existing kubernetes cluster, like minikube, will produce a lot of errors due to earlier test runs not cleaning up after themselves, or values being left `nil` leading to panics because the cluster was never created.

These changes will allow tests to run when an existing cluster is used.

To verify:

1. create a minikube cluster and install flux into it
2. run all the tests with the following command (assuming the kube config minikube uses is at `~/.kube/config/`)

```shell
$ E2E_KUBECONFIG=~/.kube/config just e2e-test-all
```

<!--
 Copyright 2025 Nutanix. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->

**Which issue(s) does this PR fix?**:

There is no issue for this PR.

